### PR TITLE
Disabled the functionality of remove()

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ Functions offered:
 
   Prints all the query IDs attached to every query.
 
-* remove(q_ids: list):
-
-  Removes all the queries given in the list argument "q_ids". And re-renders the remaining queries.
-
 ## Usage
 
 1. [Install](#installation) the package.

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -177,31 +177,6 @@ person sub entity,
         # Add assertions to test the behavior of the owns function
         self.assertEqual(self.builder.get_schema(), expected_output, message)
 
-        
-    def test_remove(self):
-        self.builder.sub("name","attribute","string")
-        self.builder.regex("name","[ABC]*")
-        self.builder.sub("person","entity")
-        self.builder.owns("person","name")
-        qid=self.builder.unique("person","name")
-        self.builder.key("person","name")
-        self.builder.remove([qid])
-
-        expected_output = """define
-name sub attribute,
-    value string,
-    regex "[ABC]*";
-person sub entity,
-    owns name,
-    owns name @key;"""
-
-
-
-        message = "remove method failed"
-        
-        # Add assertions to test the behavior of the owns function
-        self.assertEqual(self.builder.get_schema(), expected_output, message)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/typedbSchemaBuilder/Builder.py
+++ b/typedbSchemaBuilder/Builder.py
@@ -398,22 +398,6 @@ class Builder:
         query_type = query[0]
         getattr(self, query_type)(*query[1:])
 
-    def remove(self, q_ids: list):
-        n = len(self._query_log)
-        self._schema = "define"
-        self._context = "?#"
-
-        old_query_log = deque()
-        old_query_log, self._query_log = self._query_log, old_query_log
-
-        self.init_types()
-        for i in range(0, n):
-            query = old_query_log[0]
-            old_query_log.popleft()
-            if query[-1] in q_ids:
-                continue
-            self.make_query(query)
-
     def print_query_log(self):
         for q in self._query_log:
             print(q)


### PR DESCRIPTION
We disable the remove() function by removing the appropriate code, alongside removing its tests and mentions in the README.
This PR closes [#2](https://github.com/typedb-osi/typedb-schema-builder/issues/2)