### PR TITLE
Refactor "query" terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,6 @@ Functions offered:
 
   Prints all the query IDs attached to every query.
 
-* remove(q_ids: list):
-
-  Removes all the queries given in the list argument "q_ids". And re-renders the remaining queries.
-
 ## Usage
 
 1. [Install](#installation) the package.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TypeDB Schema Builder
 
-TypeDB schema builder package can be used to construct a TypeQL define query with native Python code.
+TypeDB schema builder package can be used to construct a TypeQL define constraint with native Python code.
 
 ## Installation
 
@@ -19,39 +19,39 @@ Functions offered:
 
 * abstract(type: str):
 
-  Makes type abstract. Returns qid attached to the query.
+  Makes type abstract. Returns qid attached to the constraint.
 
 * sub(subtype: str, type: str,value: str):
 
-  Create a new type given as argument "subtype" with supertype given as argument "type". The value parameter needs to be mentioned only when defining types with root type "attribute". Returns qid attached to the query.
+  Create a new type given as argument "subtype" with supertype given as argument "type". The value parameter needs to be mentioned only when defining types with root type "attribute". Returns qid attached to the constraint.
 
 * owns(type: str, owns: str):
 
-  Assigns ownership of attribute given as argument "owns" to type given as argument "type". Returns qid attached to the query.
+  Assigns ownership of attribute given as argument "owns" to type given as argument "type". Returns qid attached to the constraint.
 
 * owns_as(type: str, to_own: str, from_own: str):
 
-  Assigns ownership of attribute given as argument "from_own" to alias given as argument "to_own" to type given as argument "type". Returns qid attached to the query.
+  Assigns ownership of attribute given as argument "from_own" to alias given as argument "to_own" to type given as argument "type". Returns qid attached to the constraint.
 
 * relates(type: str, role: str):
 
-  Adds a role given as argument "role" to a relationship type given as argument "type". Returns qid attached to the query.
+  Adds a role given as argument "role" to a relationship type given as argument "type". Returns qid attached to the constraint.
 
 * relates_as(type: str, to_role: str, from_role: str):
 
-  Adds a role given as argument "from_role" to an alias given as argument "to_role" to type given as argument "type". Returns qid attached to the query.
+  Adds a role given as argument "from_role" to an alias given as argument "to_role" to type given as argument "type". Returns qid attached to the constraint.
 
 * plays(type: str, relation: str, role: str):
 
-  Assigns the relation:role, where relation is given as argument "relation" and role is given as argument "role" to the type given as argument "type". Returns qid attached to the query.
+  Assigns the relation:role, where relation is given as argument "relation" and role is given as argument "role" to the type given as argument "type". Returns qid attached to the constraint.
 
 * plays_as(type: str, relation: str, to_role: str, from_role: str):
 
-  Assigns the relation:role, where relation is given as argument "relation" and role is given as argument "from_role" to alias given as "to_role" to the type given as argument "type". Returns qid attached to the query.
+  Assigns the relation:role, where relation is given as argument "relation" and role is given as argument "from_role" to alias given as "to_role" to the type given as argument "type". Returns qid attached to the constraint.
 
 * regex(type: str, regex: str):
 
-  Adds a regex pattern given as argument "regex" to attribute type given as argument "type". Returns qid attached to the query.
+  Adds a regex pattern given as argument "regex" to attribute type given as argument "type". Returns qid attached to the constraint.
 
 * key(type: str, attribute: str):
 
@@ -59,19 +59,19 @@ Functions offered:
 
 * unique(self, type: str, attribute: str):
 
-  Makes the attribute given as an argument "attribute" that is owned by type given as argument "type" a @unique attribute. Returns qid attached to the query.
+  Makes the attribute given as an argument "attribute" that is owned by type given as argument "type" a @unique attribute. Returns qid attached to the constraint.
 
-* print_query_log():
+* print_constraint_log():
 
-  Prints all the query IDs attached to every query.
+  Prints all the constraint IDs attached to every constraint.
 
 ## Usage
 
 1. [Install](#installation) the package.
 2. Import the `Builder` from the package in your code. 
 3. Instantiate the `Builder.Builder()`.
-4. Use [methods](#methods) mentioned above to construct a query.
-5. Use `get_schema()` method to retrieve TypeQL query.
+4. Use [methods](#methods) mentioned above to construct a constraint.
+5. Use `get_schema()` method to retrieve TypeQL constraint.
 
 ### Example
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -177,31 +177,6 @@ person sub entity,
         # Add assertions to test the behavior of the owns function
         self.assertEqual(self.builder.get_schema(), expected_output, message)
 
-        
-    def test_remove(self):
-        self.builder.sub("name","attribute","string")
-        self.builder.regex("name","[ABC]*")
-        self.builder.sub("person","entity")
-        self.builder.owns("person","name")
-        qid=self.builder.unique("person","name")
-        self.builder.key("person","name")
-        self.builder.remove([qid])
-
-        expected_output = """define
-name sub attribute,
-    value string,
-    regex "[ABC]*";
-person sub entity,
-    owns name,
-    owns name @key;"""
-
-
-
-        message = "remove method failed"
-        
-        # Add assertions to test the behavior of the owns function
-        self.assertEqual(self.builder.get_schema(), expected_output, message)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/typedbSchemaBuilder/Builder.py
+++ b/typedbSchemaBuilder/Builder.py
@@ -398,22 +398,6 @@ class Builder:
         query_type = query[0]
         getattr(self, query_type)(*query[1:])
 
-    def remove(self, q_ids: list):
-        n = len(self._query_log)
-        self._schema = "define"
-        self._context = "?#"
-
-        old_query_log = deque()
-        old_query_log, self._query_log = self._query_log, old_query_log
-
-        self.init_types()
-        for i in range(0, n):
-            query = old_query_log[0]
-            old_query_log.popleft()
-            if query[-1] in q_ids:
-                continue
-            self.make_query(query)
-
     def print_query_log(self):
         for q in self._query_log:
             print(q)

--- a/typedbSchemaBuilder/Exceptions.py
+++ b/typedbSchemaBuilder/Exceptions.py
@@ -8,9 +8,9 @@ import copy
 
 
 class SchemaChecker:
-    def __init__(self, schema: str, query_log: deque, types_: dict) -> None:
+    def __init__(self, schema: str, constraints_log: deque, types_: dict) -> None:
         self.schema = schema
-        self.query_log = query_log
+        self.constraints_log = constraints_log
         self.types = types_
 
     def test(self) -> None:
@@ -21,8 +21,8 @@ class SchemaChecker:
         self.key_unique_ownership_check()
         # Check for defination availability
 
-    def grammar_check(self, query: str) -> bool:
-        lexer = TypeQLLexer(InputStream(query))
+    def grammar_check(self, constraints: str) -> bool:
+        lexer = TypeQLLexer(InputStream(constraints))
         lexer.removeErrorListeners()  # Remove default error listeners
         lexer.addErrorListener(MyErrorListener())
         stream = CommonTokenStream(lexer)
@@ -35,40 +35,40 @@ class SchemaChecker:
             raise Exception(e)
 
     def check_regex(self) -> None:
-        query_log_twin = copy.deepcopy(self.query_log)
-        n = len(query_log_twin)
+        constraints_log_twin = copy.deepcopy(self.constraints_log)
+        n = len(constraints_log_twin)
         for i in range(0, n):
-            query = query_log_twin[0]
-            query_log_twin.popleft()
-            if query[0] == "regex":
-                expression = r"" + query[2]
+            constraints = constraints_log_twin[0]
+            constraints_log_twin.popleft()
+            if constraints[0] == "regex":
+                expression = r"" + constraints[2]
                 re.compile(expression)
 
     # Does not work properly (flawed logic), needs to be re-written after finalising the requirements
     def abstract_match_check(self) -> None:
-        query_log_twin = copy.deepcopy(self.query_log)
-        n = len(query_log_twin)
+        constraints_log_twin = copy.deepcopy(self.constraints_log)
+        n = len(constraints_log_twin)
         for i in range(0, n):
-            query = query_log_twin[0]
-            query_log_twin.popleft()
+            constraints = constraints_log_twin[0]
+            constraints_log_twin.popleft()
             abstract_count = [0, 0]
-            for j in range(0, len(query)):
-                if query[j] in self.types.keys():
-                    if len(self.types[query[j]].super_types) == 0:
+            for j in range(0, len(constraints)):
+                if constraints[j] in self.types.keys():
+                    if len(self.types[constraints[j]].super_types) == 0:
                         continue
-                    abstract_count[self.types[query[j]].abstract] += 1
+                    abstract_count[self.types[constraints[j]].abstract] += 1
             if abstract_count[0] and abstract_count[1]:
-                raise Exception("Error: Mixed types\nqid:" + str(query[-1]))
+                raise Exception("Error: Mixed types\nqid:" + str(constraints[-1]))
 
     def super_type_check(self) -> None:
-        query_log_twin = copy.deepcopy(self.query_log)
-        n = len(query_log_twin)
+        constraints_log_twin = copy.deepcopy(self.constraints_log)
+        n = len(constraints_log_twin)
         for i in range(0, n):
-            query = query_log_twin[0]
-            query_log_twin.popleft()
-            if query[0] == "sub":
-                type = query[2]
-                subtype = query[1]
+            constraints = constraints_log_twin[0]
+            constraints_log_twin.popleft()
+            if constraints[0] == "sub":
+                type = constraints[2]
+                subtype = constraints[1]
                 if type not in self.types.keys():
                     raise Exception(
                         "Error defining subtype:"
@@ -76,7 +76,7 @@ class SchemaChecker:
                         + "\nThe type:"
                         + type
                         + "does not exist\nqid:"
-                        + str(query[-1]),
+                        + str(constraints[-1]),
                     )
                 if subtype in self.types.keys():
                     if len(self.types[subtype].super_types) > 1:
@@ -84,7 +84,7 @@ class SchemaChecker:
                             "Error defining subtype:"
                             + subtype
                             + "\nThe subtype is already defined\nqid:"
-                            + str(query[-1])
+                            + str(constraints[-1])
                         )
                     elif (
                         len(self.types[subtype].super_types)
@@ -94,18 +94,18 @@ class SchemaChecker:
                             "Error defining subtype:"
                             + subtype
                             + "\nThe subtype is already defined\nqid:"
-                            + str(query[-1])
+                            + str(constraints[-1])
                         )
 
     def key_unique_ownership_check(self) -> None:
-        query_log_twin = copy.deepcopy(self.query_log)
-        n = len(query_log_twin)
+        constraints_log_twin = copy.deepcopy(self.constraints_log)
+        n = len(constraints_log_twin)
         for i in range(0, n):
-            query = query_log_twin[0]
-            query_log_twin.popleft()
-            if query[0] == "key" or query[0] == "unique":
-                type_ = query[1]
-                owns = query[2]
+            constraints = constraints_log_twin[0]
+            constraints_log_twin.popleft()
+            if constraints[0] == "key" or constraints[0] == "unique":
+                type_ = constraints[1]
+                owns = constraints[2]
                 if owns not in self.types[type_].attributes:
                     message = (
                         "Error: Type = "
@@ -113,138 +113,138 @@ class SchemaChecker:
                         + " does not own:"
                         + owns
                         + "\nqid:"
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
 
     def predefined_type_check(self) -> None:
-        query_log_twin = copy.deepcopy(self.query_log)
-        n = len(query_log_twin)
+        constraints_log_twin = copy.deepcopy(self.constraints_log)
+        n = len(constraints_log_twin)
         for i in range(0, n):
-            query = query_log_twin[0]
-            query_log_twin.popleft()
-            if query[0] in ["abstract", "value", "regex"]:
-                if query[1] not in self.types.keys():
+            constraints = constraints_log_twin[0]
+            constraints_log_twin.popleft()
+            if constraints[0] in ["abstract", "value", "regex"]:
+                if constraints[1] not in self.types.keys():
                     message = (
                         "Error: type = "
-                        + query[1]
+                        + constraints[1]
                         + " is not defined"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
 
-            elif query[0] in ["relates", "relates_as"]:
-                if query[1] not in self.types.keys():
+            elif constraints[0] in ["relates", "relates_as"]:
+                if constraints[1] not in self.types.keys():
                     message = (
                         "Error: type = "
-                        + query[1]
+                        + constraints[1]
                         + " is not defined"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-                elif "relation" != self.types[query[1]].root_type:
+                elif "relation" != self.types[constraints[1]].root_type:
                     message = (
                         "Error:"
-                        + query[1]
+                        + constraints[1]
                         + " is not an relation type"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-            elif query[0] in ["owns", "owns_as", "key", "unique"]:
-                if query[1] not in self.types.keys():
+            elif constraints[0] in ["owns", "owns_as", "key", "unique"]:
+                if constraints[1] not in self.types.keys():
                     message = (
                         "Error: type = "
-                        + query[1]
+                        + constraints[1]
                         + " is not defined"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-                elif "entity" != self.types[query[1]].root_type:
+                elif "entity" != self.types[constraints[1]].root_type:
                     message = (
                         "Error:"
-                        + query[1]
+                        + constraints[1]
                         + " is not an entity type"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
 
-                if query[-2] not in self.types.keys():
+                if constraints[-2] not in self.types.keys():
                     message = (
                         "Error:"
-                        + query[-2]
+                        + constraints[-2]
                         + " is not defined"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-                elif "attribute" != self.types[query[-2]].root_type:
+                elif "attribute" != self.types[constraints[-2]].root_type:
                     message = (
                         "Error:"
-                        + query[-2]
+                        + constraints[-2]
                         + " is not an attribute type"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-            elif query[0] in ["sub"]:
-                if query[2] not in self.types.keys():
+            elif constraints[0] in ["sub"]:
+                if constraints[2] not in self.types.keys():
                     message = (
                         "Error: type = "
-                        + query[2]
+                        + constraints[2]
                         + " is not defined"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-            elif query[0] in ["plays", "plays_as"]:
-                if query[1] not in self.types.keys():
+            elif constraints[0] in ["plays", "plays_as"]:
+                if constraints[1] not in self.types.keys():
                     message = (
                         "Error: type = "
-                        + query[1]
+                        + constraints[1]
                         + " is not defined"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-                if "entity" != self.types[query[1]].root_type:
+                if "entity" != self.types[constraints[1]].root_type:
                     message = (
                         "Error: not entity, type = "
-                        + query[1]
+                        + constraints[1]
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
 
-                if query[2] not in self.types.keys():
+                if constraints[2] not in self.types.keys():
                     message = (
                         "Error: relationship type = "
-                        + query[2]
+                        + constraints[2]
                         + " is not defined"
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
-                if "relation" != self.types[query[2]].root_type:
+                if "relation" != self.types[constraints[2]].root_type:
                     message = (
                         "Error: not relationship, type = "
-                        + query[2]
+                        + constraints[2]
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)
 
-                if query[-2] not in self.types[query[2]].relation_roles:
+                if constraints[-2] not in self.types[constraints[2]].relation_roles:
                     message = (
                         "Error: relationship type = "
-                        + query[2]
+                        + constraints[2]
                         + " has no role = "
-                        + query[-2]
+                        + constraints[-2]
                         + "\nqid: "
-                        + str(query[-1])
+                        + str(constraints[-1])
                     )
                     raise Exception(message)


### PR DESCRIPTION
We refactor the 'query' terminology throughout the code, and replaced it by 'constraint' wherever applicable both internal to the code and interfaces exposed to the user.
We do not alter the 'query' terminology, when used in TypeQL syntaxes.
This PR closes [#4](https://github.com/typedb-osi/typedb-schema-builder/issues/4)